### PR TITLE
Fix for file name text overflow 

### DIFF
--- a/web/css/tempic-front.css
+++ b/web/css/tempic-front.css
@@ -72,6 +72,12 @@ form {
 	margin: 0 auto 10px;
 }
 
+.panel-body p {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+}
+
 .std-hide {
   display: none;
 }

--- a/web/index.php
+++ b/web/index.php
@@ -357,7 +357,7 @@ require_once('../includes/qrcode-interface.php');
 														<img src="<?php echo $file_ext_icon; ?>" alt="Uploaded File" class="img-responsive">
 													<?php endif; ?>
 
-													<p> title="<?php echo htmlspecialchars($name); ?>" <?php echo htmlspecialchars($name); ?></p>
+													<p title="<?php echo htmlspecialchars($name); ?>"> <?php echo htmlspecialchars($name); ?></p>
 												</a>
 												<pre class="checksum-field"><?php
 													if (empty($file['checksums']))

--- a/web/index.php
+++ b/web/index.php
@@ -357,7 +357,7 @@ require_once('../includes/qrcode-interface.php');
 														<img src="<?php echo $file_ext_icon; ?>" alt="Uploaded File" class="img-responsive">
 													<?php endif; ?>
 
-													<p><?php echo htmlspecialchars($name); ?></p>
+													<p> title="<?php echo htmlspecialchars($name); ?>" <?php echo htmlspecialchars($name); ?></p>
 												</a>
 												<pre class="checksum-field"><?php
 													if (empty($file['checksums']))


### PR DESCRIPTION
When uploading a file with a long file name, an overflow is caused in the overview that looks like this :
![overflow](https://user-images.githubusercontent.com/5342058/38177030-eaca142c-35f9-11e8-905c-778673460705.PNG)
My modified version in this request will automatically fix this behaviour by ending long file names with an ellipsis. Hovering over the file name will reveal the full name:
![overflow_after](https://user-images.githubusercontent.com/5342058/38177060-8b785c80-35fa-11e8-9566-a0ec300dda14.PNG)
